### PR TITLE
Exclude files when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+1.29.2/functions
+1.29.2/globals
+1.29.2/natives
+1.29.2/types
+
+1.32.10/functions
+1.32.10/globals
+1.32.10/natives
+1.32.10/types
+
+1.33.0/natives


### PR DESCRIPTION
Significantly reduces the package size by not including build-only files. We could probably just exclude *.json (package.json is included regardless) but I figure explicitly ignoring the directories works well enough.